### PR TITLE
Adds Apache 2.4 support for koha-gitify installs

### DIFF
--- a/koha-gitify
+++ b/koha-gitify
@@ -111,7 +111,21 @@ my $aconf = "/etc/apache2/sites-available/$instancename";
 # newer version of koha use this naming sheme
 unless (-e $aconf){
     $aconf .= '.conf';
+    copy_wrapper($aconf, "$aconf.bkp");
+    %replaces = (
+    # Indranil Das Gupta - adding Apache 2.4 support for gitified install's DOCROOT
+    # replace this ...                           with all of this
+    '# Koha instance kohamaster Apache config.' => "# Koha instance kohamaster Apache config.\n\n"
+    . "# Add Apache 2.4 support for gitified install\n"
+    . "<Directory $gitcheckout>\n"
+    . "   Options Indexes FollowSymLinks\n"
+    . "   AllowOverride None\n"
+    . "   Require all granted\n"
+    . "</Directory>\n\n",
+);
 }
+
+build("$aconf.bkp", $aconf, \%replaces);
 
 copy_wrapper($aconf, "$aconf.bkp");
 %replaces = (


### PR DESCRIPTION
See http://wiki.koha-community.org/wiki/Koha_on_ubuntu_-_packages#403_errors_for_Gitified_or_git_clone_installs for details of the issue fixed.